### PR TITLE
LIBITD-2566. Table and single-button form styles.

### DIFF
--- a/src/umd_lib_style/static/umd_lib_style/umd_lib_style.css
+++ b/src/umd_lib_style/static/umd_lib_style/umd_lib_style.css
@@ -296,6 +296,25 @@ summary>* {
     margin: 0;
 }
 
+/* Forms
+
+The `button` class should be applied to forms whose only visible control is a
+single button. This class makes the form render as an inline-block element so
+it can be placed alongside links or other inline content.
+
+These forms will typically have one or more hidden fields. The single button
+will usually have an action class (see "Form controls" below)
+
+    form.button
+        (input@type=hidden)*
+        button.{action}
+
+*/
+form.button {
+    display: inline-block;
+    margin: 0;
+}
+
 /* Form controls
 
 Includes standardized button class names of "create", "edit", "update", and "delete".

--- a/src/umd_lib_style/static/umd_lib_style/umd_lib_style.css
+++ b/src/umd_lib_style/static/umd_lib_style/umd_lib_style.css
@@ -34,8 +34,13 @@
     --light-gray-shaded: color-mix(in srgb, var(--light-gray), black var(--shading-percentage));
     --medium-gray-shaded: color-mix(in srgb, var(--medium-gray), black var(--shading-percentage));
 
-    --table-background-color: #fcfcfc;
+    /* tables */
+    --table-cell-padding: .5em;
     --table-border-color: var(--medium-gray);
+    --table-background-color: #fcfcfc;
+    --table-background-color-shaded: color-mix(in srgb, var(--table-background-color), 25% black);
+    /* used for striping or highlighting */
+    --table-alternate-background-color: color-mix(in srgb, var(--table-background-color), 10% black);
 
     /* for rounded UI elements */
     --rounded-border-radius: 5px;
@@ -169,24 +174,48 @@ footer {
 table {
     border-collapse: collapse;
 }
-
-th,
-td {
-    border: 1px solid var(--table-border-color);
-    padding: .5em;
+th, td {
+    padding: var(--table-cell-padding);
 }
-th {
-    background-color: color-mix(in srgb, var(--table-background-color), 25% black);
+
+/* Table display with full borders on each cell, zebra striping,
+   and dark background header cells
+*/
+table.grid th,
+table.grid td
+{
+    border: 1px solid var(--table-border-color);
+}
+table.grid th {
+    background-color: var(--table-background-color-shaded);
     color: black;
 }
-td {
+table.grid td {
     background-color: var(--table-background-color);
     color: black;
 }
-tbody tr:nth-child(2n) td {
-    background-color: color-mix(in srgb, var(--table-background-color), 10% black);
+table.grid tbody tr:nth-child(2n) td {
+    background-color: var(--table-alternate-background-color);
     color: black;
 }
+
+/* Lightweight table display that simply uses horizontal lines between each row */
+table.lined td,
+table.lined th
+{
+    text-align: left;
+}
+table.lined tr {
+    border-top: 1px solid var(--table-border-color);
+    border-bottom: 1px solid var(--table-border-color);
+}
+table.lined thead tr {
+    border-top: none;
+}
+table.lined tbody tr:hover {
+    background-color: var(--table-alternate-background-color);
+}
+
 
 /* Environment Banner
 


### PR DESCRIPTION
**Expanded table styles**

- moved the current default table styling (originated in Grove) to the `table.grid` class
- added a `table.lined` lighter weight table display style that is similar to Bootstrap's default table styling
- added more table-related variables

**Single-button form styling**

- Added selector to use to make single button forms display inline.

https://umd-dit.atlassian.net/browse/LIBITD-2566